### PR TITLE
Add GitHub Action for Firebase deploy

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,0 +1,25 @@
+name: Firebase Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+      - name: Install Functions dependencies
+        run: npm ci --prefix functions
+      - name: Deploy to Firebase
+        uses: w9jds/firebase-action@v13.1.0
+        with:
+          args: deploy
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
## Summary
- create a GitHub Actions workflow to deploy Firebase functions and hosting on pushes to `main`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68864cb363a88333a84fa4961a2bf85d