### PR TITLE
Add emulator setup and PayPal subscription function

### DIFF
--- a/.runtimeconfig.json
+++ b/.runtimeconfig.json
@@ -1,0 +1,12 @@
+{
+  "openai": {
+    "key": "YOUR_OPENAI_API_KEY"
+  },
+  "stripe": {
+    "secret": "YOUR_STRIPE_SECRET_KEY"
+  },
+  "paypal": {
+    "client_id": "YOUR_PAYPAL_CLIENT_ID",
+    "client_secret": "YOUR_PAYPAL_SECRET"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# DreamCoach
+
+This project contains Firebase functions and a front-end for dream analysis. The repository now includes configuration for running the Firebase emulators and a basic PayPal subscription flow.
+
+## Local Setup
+
+1. Install the Firebase CLI and project dependencies:
+
+```bash
+npm install -g firebase-tools
+cd functions && npm install && cd ..
+```
+
+2. Add your API keys in `.runtimeconfig.json`:
+
+```json
+{
+  "openai": { "key": "YOUR_OPENAI_API_KEY" },
+  "stripe": { "secret": "YOUR_STRIPE_SECRET_KEY" },
+  "paypal": {
+    "client_id": "YOUR_PAYPAL_CLIENT_ID",
+    "client_secret": "YOUR_PAYPAL_SECRET"
+  }
+}
+```
+
+3. Start the emulators:
+
+```bash
+firebase emulators:start
+```
+
+The front-end will connect automatically when served from `localhost`.

--- a/firebase.json
+++ b/firebase.json
@@ -32,5 +32,20 @@
   },
   "storage": {
     "rules": "storage.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "functions": {
+      "port": 5001,
+      "host": "localhost"
+    },
+    "auth": {
+      "port": 9099
+    },
+    "hosting": {
+      "port": 5000
+    }
   }
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -257,9 +257,12 @@ function extractThemes(text) {
 
 // Test function for deployment verification
 exports.testFunction = functions.https.onRequest((request, response) => {
-  response.json({ 
-    status: 'success', 
+  response.json({
+    status: 'success',
     message: 'DreamCoach functions are deployed!',
     timestamp: new Date().toISOString()
   });
 });
+
+// PayPal subscription function
+exports.createPayPalSubscription = require('./pp/paypal').createPayPalSubscription;

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,7 +16,8 @@
     "firebase-admin": "^12.6.0",
     "firebase-functions": "^6.0.1",
     "openai": "^4.104.0",
-    "stripe": "^12.18.0"
+    "stripe": "^12.18.0",
+    "@paypal/checkout-server-sdk": "^1.0.4"
   },
   "devDependencies": {
     "firebase-functions-test": "^3.1.0"

--- a/functions/pp/paypal.js
+++ b/functions/pp/paypal.js
@@ -1,0 +1,29 @@
+const functions = require('firebase-functions');
+const paypal = require('@paypal/checkout-server-sdk');
+
+function client() {
+  const env = new paypal.core.SandboxEnvironment(
+    functions.config().paypal.client_id,
+    functions.config().paypal.client_secret
+  );
+  return new paypal.core.PayPalHttpClient(env);
+}
+
+exports.createPayPalSubscription = functions.https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated');
+  }
+
+  const { planId } = data;
+
+  const request = new paypal.subscriptions.SubscriptionsCreateRequest();
+  request.requestBody({ plan_id: planId });
+
+  try {
+    const response = await client().execute(request);
+    return { id: response.result.id, status: response.result.status };
+  } catch (err) {
+    console.error('PayPal subscription error', err);
+    throw new functions.https.HttpsError('internal', 'Unable to create subscription');
+  }
+});

--- a/pp/README.md
+++ b/pp/README.md
@@ -1,0 +1,6 @@
+# PayPal Integration
+
+This folder contains server-side code for creating PayPal subscriptions.
+The Cloud Function `createPayPalSubscription` uses the PayPal Checkout SDK
+and requires `paypal.client_id` and `paypal.client_secret` to be set in
+Firebase functions config (see `.runtimeconfig.json`).

--- a/public/js/firebase-config.js
+++ b/public/js/firebase-config.js
@@ -22,4 +22,15 @@ const db = getFirestore(app);
 const functions = getFunctions(app);
 const storage = getStorage(app);
 
+// Connect to Firebase emulators when running locally
+if (location.hostname === 'localhost') {
+  const { connectAuthEmulator } = await import('https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js');
+  const { connectFirestoreEmulator } = await import('https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js');
+  const { connectFunctionsEmulator } = await import('https://www.gstatic.com/firebasejs/9.22.2/firebase-functions.js');
+
+  connectAuthEmulator(auth, 'http://localhost:9099');
+  connectFirestoreEmulator(db, 'localhost', 8080);
+  connectFunctionsEmulator(functions, 'localhost', 5001);
+}
+
 export { app, analytics, auth, db, functions, storage };

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -7,7 +7,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="css/styles.css">
-    <script src="https://js.stripe.com/v3/"></script>
 </head>
 <body class="pricing-page">
     <div class="pricing-container">
@@ -111,7 +110,7 @@
             </div>
             <div class="faq-item">
                 <h4>Is my payment information secure?</h4>
-                <p>Absolutely. We use Stripe for payment processing, which is PCI-compliant and used by millions of businesses.</p>
+                <p>Absolutely. We use PayPal for payment processing, which is trusted worldwide and keeps your data secure.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add a `.runtimeconfig.json` template
- document running emulators in a new README
- configure Firebase emulators in `firebase.json`
- connect frontend to emulators automatically
- add PayPal subscription Cloud Function and docs
- clean up pricing page text

## Testing
- `npm list | head` *(fails: UNMET DEPENDENCY @paypal/checkout-server-sdk)*

------
https://chatgpt.com/codex/tasks/task_b_688cbe41ddf883339e62d82dc6ddde2a