### PR TITLE
Enable pricing access without login and hook up auth actions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -99,8 +99,9 @@
     </div>
 
     <script type="module" src="js/firebase-config.js"></script>
-    <script type="module" src="js/auth.js"></script>
     <script type="module">
+        import AuthManager from './js/auth.js';
+
         // Modal handling
         const authModal = document.getElementById('authModal');
         const startFreeBtn = document.getElementById('startFreeBtn');
@@ -109,6 +110,7 @@
         const nameGroup = document.getElementById('nameGroup');
         const submitBtnText = document.getElementById('submitBtnText');
         const authForm = document.getElementById('authForm');
+        const googleSignInBtn = document.getElementById('googleSignInBtn');
 
         // Show modal
         function showAuthModal(mode = 'signin') {
@@ -130,7 +132,7 @@
                 const tab = button.dataset.tab;
                 tabButtons.forEach(btn => btn.classList.remove('active'));
                 button.classList.add('active');
-                
+
                 if (tab === 'signup') {
                     nameGroup.style.display = 'block';
                     submitBtnText.textContent = 'Sign Up';
@@ -139,6 +141,40 @@
                     submitBtnText.textContent = 'Sign In';
                 }
             });
+        });
+
+        // Auth form submission
+        authForm.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const mode = document.querySelector('.tab-button.active').dataset.tab;
+            const email = document.getElementById('email').value;
+            const password = document.getElementById('password').value;
+            const name = document.getElementById('name').value;
+
+            try {
+                await AuthManager.authStatePromise;
+                if (mode === 'signup') {
+                    await AuthManager.signUp(email, password, name);
+                } else {
+                    await AuthManager.signIn(email, password);
+                }
+                authModal.classList.add('hidden');
+            } catch (err) {
+                console.error(err);
+                alert(err.message);
+            }
+        });
+
+        // Google sign in
+        googleSignInBtn.addEventListener('click', async () => {
+            try {
+                await AuthManager.authStatePromise;
+                await AuthManager.signInWithGoogle();
+                authModal.classList.add('hidden');
+            } catch (err) {
+                console.error(err);
+                alert(err.message);
+            }
         });
 
         // Event listeners

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -91,7 +91,7 @@ class AuthManager {
         window.location.href = '/app.html';
       }
     } else {
-      if (window.location.pathname.startsWith('/app') || window.location.pathname.startsWith('/pricing')) {
+      if (window.location.pathname.startsWith('/app')) {
         window.location.href = '/';
       }
     }

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -124,16 +124,8 @@
         import { functions } from './js/firebase-config.js';
         import { httpsCallable } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-functions.js';
 
-        (async () => {
-            try {
-                await AuthManager.requireAuth();
-                initializeApp();
-            } catch (error) {
-                console.log(error.message); // Should log "Redirecting to login"
-                // The script will stop execution here if not authenticated
-            }
-        })();
-        
+        initializeApp();
+
         function initializeApp() {
             const urlParams = new URLSearchParams(window.location.search);
             const isTestMode = urlParams.get('test') === 'true';
@@ -147,6 +139,12 @@
             annualBtn.addEventListener('click', () => handlePlanSelection('annual'));
 
             async function handlePlanSelection(planType) {
+                try {
+                    await AuthManager.requireAuth();
+                } catch (error) {
+                    return; // User will be redirected to login
+                }
+
                 if (isTestMode) {
                     await activateTestSubscription(planType);
                     return;
@@ -154,11 +152,11 @@
 
                 // Show payment modal
                 paymentModal.classList.remove('hidden');
-                
+
                 try {
                     // Create checkout session
                     const createCheckoutSession = httpsCallable(functions, 'createCheckoutSession');
-                    const { data } = await createCheckoutSession({ 
+                    const { data } = await createCheckoutSession({
                         planType,
                         successUrl: window.location.origin + '/app.html?payment=success',
                         cancelUrl: window.location.origin + '/pricing.html'


### PR DESCRIPTION
## Summary
- Allow unauthenticated users to stay on pricing page by removing redirect
- Require auth only when selecting a plan and create checkout session
- Wire up sign in/sign up form and Google sign-in on landing page

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68a7211525888333ac8870413f2001cb