### PR TITLE
fix: pin PayPal SDK and add submodule config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dreamcoach-firebase"]
+    path = dreamcoach-firebase
+    url = https://github.com/meirhorwitz/dreamcoach-firebase.git

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "functions",
       "dependencies": {
-        "@paypal/paypal-server-sdk": "^1.1.0",
+        "@paypal/paypal-server-sdk": "1.1.0",
         "firebase-admin": "^12.6.0",
         "firebase-functions": "^6.0.1",
         "openai": "^4.104.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,7 +13,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "@paypal/paypal-server-sdk": "^1.1.0",
+    "@paypal/paypal-server-sdk": "1.1.0",
     "firebase-admin": "^12.6.0",
     "firebase-functions": "^6.0.1",
     "openai": "^4.104.0",


### PR DESCRIPTION
## Summary
- pin PayPal SDK dependency to supported 1.1.0
- add dreamcoach-firebase submodule configuration

## Testing
- `npm install`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a9cd0beab0833382f0a096048761f4