### PR TITLE
Fix Firebase deploy action to use service account key

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           args: deploy
         env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DREAMANALYSIS_39322 }}
+          GCP_SA_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DREAMANALYSIS_39322 }}


### PR DESCRIPTION
## Summary
- use `GCP_SA_KEY` instead of deprecated `FIREBASE_TOKEN` for w9jds/firebase-action

## Testing
- `npm test --prefix functions` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a9d1ea2b0083338a3bb222c56e19ba